### PR TITLE
Fixes driver timeout

### DIFF
--- a/src/factr_teleop/factr_teleop/dynamixel/driver.py
+++ b/src/factr_teleop/factr_teleop/dynamixel/driver.py
@@ -161,14 +161,17 @@ class DynamixelDriver(DynamixelDriverProtocol):
             if dxl_comm_result != COMM_SUCCESS or dxl_error != 0 or mode != expected_mode:
                 raise RuntimeError(f"Operating mode mismatch for Dynamixel ID {dxl_id}")
 
-    def get_positions_and_velocities(self):
+    def get_positions_and_velocities(self, tries=10):
         _positions = np.zeros(len(self._ids), dtype=int)
         _velocities = np.zeros(len(self._ids), dtype=int)
         
         # perform the group sync read transaction
         dxl_comm_result = self._groupSyncRead.txRxPacket()
         if dxl_comm_result != COMM_SUCCESS:
-            raise RuntimeError(f"Warning, communication failed: {dxl_comm_result}")
+            if tries > 0:
+                return self.get_positions_and_velocities(tries-1)
+            else:
+                raise RuntimeError(f"Warning, communication failed: {dxl_comm_result}")
         
         for i, dxl_id in enumerate(self._ids):
             # read velocity data


### PR DESCRIPTION
Sometimes, faulty cables will cause data packets to be dropped. This PR is to add a small modification to `get_positions_and_velocities` in the dynamixel driver to try requesting the packet 10 times before erroring out.

## Summary by Sourcery

Add retry mechanism to get_positions_and_velocities to handle intermittent packet drops

Bug Fixes:
- Retry communication up to 10 times before erroring out to mitigate data packet loss

Enhancements:
- Introduce optional tries parameter and recursive retry logic for group sync reads in the Dynamixel driver